### PR TITLE
getLineHTMLForExport - don't replace custom tags by other plugins

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -3,8 +3,8 @@
     {
       "name": "main",
       "client_hooks": {
+        "postToolbarInit": "ep_align/static/js/index",
         "aceDomLinePreProcessLineAttributes": "ep_align/static/js/index",
-        "postAceInit": "ep_align/static/js/index",
         "aceInitialized": "ep_align/static/js/index",
         "aceAttribsToClasses": "ep_align/static/js/index",
         "collectContentPre": "ep_align/static/js/shared",
@@ -14,6 +14,7 @@
         "eejsBlock_editbarMenuLeft": "ep_align/index",
         "collectContentPre": "ep_align/static/js/shared",
         "collectContentPost": "ep_align/static/js/shared",
+        "padInitToolbar": "ep_align/server_hooks",
         "getLineHTMLForExport": "ep_align/index",
         "eejsBlock_dd_format":"ep_align/index"
       }

--- a/ep.json
+++ b/ep.json
@@ -14,7 +14,7 @@
         "eejsBlock_editbarMenuLeft": "ep_align/index",
         "collectContentPre": "ep_align/static/js/shared",
         "collectContentPost": "ep_align/static/js/shared",
-        "padInitToolbar": "ep_align/server_hooks",
+        "padInitToolbar": "ep_align/index",
         "getLineHTMLForExport": "ep_align/index",
         "eejsBlock_dd_format":"ep_align/index"
       }

--- a/index.js
+++ b/index.js
@@ -41,12 +41,10 @@ function getInlineStyle(header) {
 exports.getLineHTMLForExport = function (hook, context) {
   var header = _analyzeLine(context.attribLine, context.apool);
   var lineContent = context.lineContent;
-
   if (header) {
     var inlineStyle = getInlineStyle(header);
     context.lineContent = "<" + header + " style=\"" + inlineStyle + "\">" + lineContent + "</" + header + ">";
   }
-  
 }
 
 

--- a/index.js
+++ b/index.js
@@ -40,9 +40,13 @@ function getInlineStyle(header) {
 // line, apool,attribLine,text
 exports.getLineHTMLForExport = function (hook, context) {
   var header = _analyzeLine(context.attribLine, context.apool);
+  var lineContent = context.lineContent;
   if (header) {
     var inlineStyle = getInlineStyle(header);
-    return "<" + header + " style=\"" + inlineStyle + "\">" + context.text.substring(1) + "</" + header + ">";
+    if(lineContent[0] === '*') {
+      lineContent = lineContent.replace('*', '');
+    }
+    return "<" + header + " style=\"" + inlineStyle + "\">" + lineContent + "</" + header + ">";
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -41,14 +41,14 @@ function getInlineStyle(header) {
 exports.getLineHTMLForExport = function (hook, context) {
   var header = _analyzeLine(context.attribLine, context.apool);
   var lineContent = context.lineContent;
+
   if (header) {
     var inlineStyle = getInlineStyle(header);
-    if(lineContent[0] === '*') {
-      lineContent = lineContent.replace('*', '');
-    }
-    return "<" + header + " style=\"" + inlineStyle + "\">" + lineContent + "</" + header + ">";
+    context.lineContent = "<" + header + " style=\"" + inlineStyle + "\">" + lineContent + "</" + header + ">";
   }
+  
 }
+
 
 function _analyzeLine(alineAttrs, apool) {
   var header = null;

--- a/index.js
+++ b/index.js
@@ -59,3 +59,33 @@ function _analyzeLine(alineAttrs, apool) {
   }
   return header;
 }
+
+
+exports.padInitToolbar = function (hook_name, args) {
+    var toolbar = args.toolbar;
+
+    var alignLeftButton = toolbar.button({
+        command: 'alignLeft',
+        class: "buttonicon grouped-left ep_align ep_align_left"
+    });
+
+    var alignCenterButton = toolbar.button({
+        command: 'alignCenter',
+        class: "buttonicon grouped-middle ep_align ep_align_center"
+    });
+
+    var alignJustifyButton = toolbar.button({
+        command: 'alignJustify',
+        class: "buttonicon grouped-middle ep_align ep_align_justify"
+    });
+
+    var alignRightButton = toolbar.button({
+        command: 'alignRight',
+        class: "buttonicon grouped-right ep_align ep_align_right"
+    });
+
+    toolbar.registerButton('alignLeft', alignLeftButton);
+    toolbar.registerButton('alignCenter', alignCenterButton);
+    toolbar.registerButton('alignJustify', alignJustifyButton);
+    toolbar.registerButton('alignRight', alignRightButton);
+};

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -11,22 +11,25 @@ var aceRegisterBlockElements = function(){
   return tags;
 }
 
-// Bind the event handler to the toolbar buttons
-var postAceInit = function(hook, context){
-  $('.ep_align_left').click(function(){
-    align(context, 0);
-  });
-  $('.ep_align_center').click(function(){
-    align(context, 1);
-  });
-  $('.ep_align_justify').click(function(){
-    align(context, 3);
-  });
-  $('.ep_align_right').click(function(){
-    align(context, 2);
-  });
-};
+function postToolbarInit (hook_name, context) {
+    var editbar = context.toolbar; // toolbar is actually editbar - http://etherpad.org/doc/v1.5.7/#index_editbar
 
+    editbar.registerCommand('alignLeft', function () {
+      align(context, 0);
+    });
+
+    editbar.registerCommand('alignCenter',  function () {     
+       align(context, 1);
+    });
+
+    editbar.registerCommand('alignJustify',  function () {
+      align(context, 3);
+    });
+
+    editbar.registerCommand('alignRight',  function () {
+      align(context, 2);
+    });
+};
 
 function align(context, alignment){
   context.ace.callWithAce(function(ace){
@@ -104,9 +107,9 @@ function aceEditorCSS(){
 };
 
 // Export all hooks
+exports.postToolbarInit = postToolbarInit;
 exports.aceRegisterBlockElements = aceRegisterBlockElements;
 exports.aceInitialized = aceInitialized;
-exports.postAceInit = postAceInit;
 exports.aceDomLinePreProcessLineAttributes = aceDomLinePreProcessLineAttributes;
 exports.aceAttribsToClasses = aceAttribsToClasses;
 exports.aceEditorCSS = aceEditorCSS;

--- a/templates/editbarButtons.ejs
+++ b/templates/editbarButtons.ejs
@@ -1,45 +1,18 @@
-<li class="separator acl-write"></li>
-<li id="align" class="acl-write">
-  <a class="grouped-left ep_align ep_align_left" title="Align Left">
-    <span class="buttonicon"></span>
-  </a>
-</li>
-<li id="align" class="acl-write">
-  <a class="grouped-middle ep_align ep_align_center" title="Align Center">                         
-    <span class="buttonicon"></span>
-  </a>
-</li>
-<li id="align" class="acl-write">
-  <a class="grouped-middle ep_align ep_align_justify" title="Align Justify">
-    <span class="buttonicon"></span>
-  </a>
-</li>
-<li id="align" class="acl-write">
-  <a class="grouped-right ep_align ep_align_right" title="Align Right">                         
-    <span class="buttonicon"></span>
-  </a>
-</li>
 <style>
-
-  .ep_align{
-    font-family:font-awesome;
-
-  }
-
   .ep_align > .buttonicon {
     top:2px!important;
   }
 
-  .ep_align_left > .buttonicon:before{
+  button.buttonicon.grouped-left.ep_align.ep_align_left:before {
     content:"\e800";
   }
-  .ep_align_center > .buttonicon:before{
+  button.buttonicon.grouped-middle.ep_align.ep_align_center:before {
     content:"\e80f";
   }
-  .ep_align_justify > .buttonicon:before{
+  button.buttonicon.grouped-middle.ep_align.ep_align_justify:before {
     content:"\e811";
   }
-  .ep_align_right > .buttonicon:before{
+  button.buttonicon.grouped-right.ep_align.ep_align_right:before {
     content:"\e810";
   }
 	


### PR DESCRIPTION
FIXED: while using ep_font_color and ep_font_size plugins alongside ep_align, custom tags eg. <fs10> were lost during html export.