### PR TITLE
hu locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An Etherpad Plugin to apply Text Alignment in a pad.  Currently supports:
 Experimental.  As attributes are line by line on Etherpad some weirdness may be experienced.
 
 # History
-I decided to copy/pasta the ep_headings2 plugin over ep_align to fix a load of issues.
+I decided to copy/paste the ep_headings2 plugin over ep_align to fix a load of issues.
 
 # License
 Apache 2

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,7 @@
 {
-  "ep_align.align" : "Align",
-  "ep_align.left" : "Left",
-  "ep_align.middle" : "Middle",
-  "ep_align.right" : "Right",
-  "ep_align.justify" : "Justify"
+  "ep_align.align" : "",
+  "ep_align.left" : "Align Left",
+  "ep_align.middle" : "Align Center",
+  "ep_align.right" : "Align Right",
+  "ep_align.justify" : "Justified"
 }

--- a/locales/hu.json
+++ b/locales/hu.json
@@ -1,0 +1,7 @@
+{
+  "ep_align.align" : "",
+  "ep_align.left" : "Balra igazítás",
+  "ep_align.middle" : "Középre igazítás",
+  "ep_align.right" : "Jobbra igazítás",
+  "ep_align.justify" : "Sorkizárt"
+}


### PR DESCRIPTION
1. Where is the `ep_headings2 plugin`?
2. `Align Left` is written in `hu` as `Left align`. Can the `ep_align.align` string be removed?

Thank you